### PR TITLE
[bug]: Use English as default (non-supported) language

### DIFF
--- a/src/ducks/initialState.js
+++ b/src/ducks/initialState.js
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 
 const defaultImage = require('../assets/devices/default.png');
-let userLang = i18n.languages?.includes(i18n.language) ? i18n.language : 'en';
+const userLang = i18n.languages?.includes(i18n.language) ? i18n.language : 'en';
 
 const devices = [
   {id: 0, name: 'Axivity', image: defaultImage},

--- a/src/ducks/initialState.js
+++ b/src/ducks/initialState.js
@@ -2,13 +2,7 @@ import i18n from 'i18next';
 
 const defaultImage = require('../assets/devices/default.png');
 // Added a function since ./__test__/ducks/reducer-test.js failed to run i18n.languages.INCLUDES
-const userLang = () => {
-  try {
-    return i18n.languages.includes(i18n.language) ? i18n.language : 'en';
-  } catch (err) {
-    return 'en';
-  }
-};
+const userLang = i18n.languages?.includes(i18n.language) ? i18n.language : 'en';
 
 const DEVICES = [
   {id: 0, name: 'Axivity', image: defaultImage},

--- a/src/ducks/initialState.js
+++ b/src/ducks/initialState.js
@@ -1,6 +1,14 @@
 import i18n from 'i18next';
 
 const defaultImage = require('../assets/devices/default.png');
+// Added a function since ./__test__/ducks/reducer-test.js failed to run i18n.languages.INCLUDES
+const userLang = () => {
+  try {
+    return i18n.languages.includes(i18n.language) ? i18n.language : 'en';
+  } catch (err) {
+    return 'en';
+  }
+};
 
 const DEVICES = [
   {id: 0, name: 'Axivity', image: defaultImage},
@@ -18,6 +26,6 @@ const DEVICES = [
 
 export default {
   userID: null,
-  userLang: i18n.language,
+  userLang: userLang,
   devices: DEVICES,
 };

--- a/src/ducks/initialState.js
+++ b/src/ducks/initialState.js
@@ -1,9 +1,9 @@
 import i18n from 'i18next';
 
 const defaultImage = require('../assets/devices/default.png');
-const userLang = i18n.languages?.includes(i18n.language) ? i18n.language : 'en';
+let userLang = i18n.languages?.includes(i18n.language) ? i18n.language : 'en';
 
-const DEVICES = [
+const devices = [
   {id: 0, name: 'Axivity', image: defaultImage},
   {id: 1, name: 'Byteflies', image: defaultImage},
   {id: 2, name: 'Dreem', image: defaultImage},
@@ -19,6 +19,6 @@ const DEVICES = [
 
 export default {
   userID: null,
-  userLang: userLang,
-  devices: DEVICES,
+  userLang,
+  devices,
 };

--- a/src/ducks/initialState.js
+++ b/src/ducks/initialState.js
@@ -1,7 +1,6 @@
 import i18n from 'i18next';
 
 const defaultImage = require('../assets/devices/default.png');
-// Added a function since ./__test__/ducks/reducer-test.js failed to run i18n.languages.INCLUDES
 const userLang = i18n.languages?.includes(i18n.language) ? i18n.language : 'en';
 
 const DEVICES = [

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -44,6 +44,7 @@ i18n.locale = locale;
 i18n.use(initReactI18next).init({
   lng: locale.substring(0, 2),
   fallbackLng: 'en',
+  supportedLngs: ['en', 'de', 'nl'],
   resources: {
     en: {
       contributions: ContributionsEN,


### PR DESCRIPTION
- [x] Assigned a Reviewer to the **PR**.
- [x] Assigned a Project to the **PR**.

## What Changed and Why?

In the previous PR we introduced multilingual (i18n) support. However, when a user has a language on their phone set to a non-supported language (e.g. French), then the settings page breaks due to current logic. This PR resolves this bug.

## To Reproduce
  1. Set the phone's language to a not supported language (e.g. French) and navigate to Settings. Note there is an error!

## To Test
   1. Set the phone's language to a support language, e.g. English, navigate around the app and change the language from English to something else (German);
   2. Set the phone's language to one that is not supported (French) and navigate to settings.
       1. Note that there is not only no error, but that English is used as the default language.